### PR TITLE
Support STRICT_R_HEADERS via R_{Calloc,Free} and DBL_EPSILON

### DIFF
--- a/inst/include/RxODE.h
+++ b/inst/include/RxODE.h
@@ -312,7 +312,7 @@ void rxOptionsIniEnsure(int mx);
 
 void rxUpdateFuns(SEXP trans);
 
-#define _eps sqrt(DOUBLE_EPS)
+#define _eps sqrt(DBL_EPSILON)
 
 static inline double erfinv(double x)  __attribute__((unused));
 static inline double erfinv(double x) {

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -130,7 +130,7 @@ arma::vec phiv(double t, arma::mat& A, arma::vec& u,
     int mb    = m; double t_out   = fabs(t);
     int istep = 0; double t_new   = 0;
     double t_now = 0; double s_error = 0;
-    double rndoff= anorm*DOUBLE_EPS;
+    double rndoff= anorm*DBL_EPSILON;
     double sgn = (0.0 < t) - (t > 0.0);
     int k1 = 3, ireject = 0, mx=0;
     double xm = 1.0/m; 

--- a/src/lincmt.c
+++ b/src/lincmt.c
@@ -5,9 +5,9 @@
 #include <Rmath.h>
 #include <R_ext/Rdynload.h>
 #include "../inst/include/RxODE.h"
-#define safe_zero(a) ((a) == 0 ? DOUBLE_EPS : (a))
-#define _as_zero(a) (fabs(a) < sqrt(DOUBLE_EPS) ? 0.0 : a)
-#define _as_dbleps(a) (fabs(a) < sqrt(DOUBLE_EPS) ? ((a) < 0 ? -sqrt(DOUBLE_EPS)  : sqrt(DOUBLE_EPS)) : a)
+#define safe_zero(a) ((a) == 0 ? DBL_EPSILON : (a))
+#define _as_zero(a) (fabs(a) < sqrt(DBL_EPSILON) ? 0.0 : a)
+#define _as_dbleps(a) (fabs(a) < sqrt(DBL_EPSILON) ? ((a) < 0 ? -sqrt(DBL_EPSILON)  : sqrt(DBL_EPSILON)) : a)
 
 #ifdef ENABLE_NLS
 #include <libintl.h>
@@ -87,7 +87,7 @@ extern int _locateTimeIndex(double obs_time,  rx_solving_options_ind *ind){
     i--;
   }
   if (i == 0){
-    while(i < ind->ndoses-2 && fabs(obs_time  - getTime(ind->ix[i+1], ind))<= sqrt(DOUBLE_EPS)){
+    while(i < ind->ndoses-2 && fabs(obs_time  - getTime(ind->ix[i+1], ind))<= sqrt(DBL_EPSILON)){
       i++;
     }
   }
@@ -253,10 +253,10 @@ void _update_par_ptr(double t, unsigned int id, rx_solve *rx, int idx) {
 	  double *par_ptr = ind->par_ptr;
 	  double *all_times = indSample->all_times;
 	  double *y = indSample->cov_ptr + indSample->n_all_times*k;
-	  if (idxSample == 0 && fabs(t- all_times[idxSample]) < DOUBLE_EPS) {
+	  if (idxSample == 0 && fabs(t- all_times[idxSample]) < DBL_EPSILON) {
 	    par_ptr[op->par_cov[k]-1] = y[0];
 	    ind->cacheME=0;
-	  } else if (idxSample > 0 && idxSample < indSample->n_all_times && fabs(t- all_times[idxSample]) < DOUBLE_EPS) {
+	  } else if (idxSample > 0 && idxSample < indSample->n_all_times && fabs(t- all_times[idxSample]) < DBL_EPSILON) {
 	    par_ptr[op->par_cov[k]-1] = getValue(idxSample, y, indSample);
 	    if (getValue(idxSample, y, indSample) != getValue(idxSample-1, y, indSample)) {
 	      ind->cacheME=0;
@@ -1529,7 +1529,7 @@ static inline void doAdvan(double *A,// Amounts
     }
     return;
   }
-  if ((*r1) > DOUBLE_EPS  || (*r2) > DOUBLE_EPS){
+  if ((*r1) > DBL_EPSILON  || (*r2) > DBL_EPSILON){
     if (oral0){
       switch (ncmt){
       case 1: {

--- a/src/lincmtB.cpp
+++ b/src/lincmtB.cpp
@@ -1946,7 +1946,7 @@ namespace stan {
 	    Eigen::Matrix<double, Eigen::Dynamic, 1>& bolus,
 	    Eigen::Matrix<double, Eigen::Dynamic, 1>& rate) {
       double t = ct - tlast;
-      if (r1 > DOUBLE_EPS  || (oral0 && r2 > DOUBLE_EPS)){
+      if (r1 > DBL_EPSILON  || (oral0 && r2 > DBL_EPSILON)){
 	if (oral0){
 	  switch (ncmt){
 	  case 1: {
@@ -2659,7 +2659,7 @@ extern "C" double linCmtB(rx_solve *rx, unsigned int id,
       idx = _locateTimeIndex(t, ind);
       it = getTime(ind->ix[idx], ind);
     }
-    int sameTime = fabs(t-it) < sqrt(DOUBLE_EPS);
+    int sameTime = fabs(t-it) < sqrt(DBL_EPSILON);
     if (idx <= ind->solved && sameTime){
       // Pull from last solved value (cached)
       double *A = getAdvan(idx);

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2275,7 +2275,7 @@ LogicalVector rxSolveFree(){
     rxUnlock(rxSolveFreeObj);
     rxSolveFreeObj=R_NilValue;
   }
-  if (_globals.gindLin != NULL) Free(_globals.gindLin);
+  if (_globals.gindLin != NULL) R_Free(_globals.gindLin);
   rxOptionsFree(); // f77 losda free
   rxOptionsIni();// realloc f77 lsoda cache
   parseFree(0); //free parser
@@ -4580,8 +4580,8 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
 	// Inductive linearization
 	IntegerVector indLinItems = as<IntegerVector>(indLin[3]);
 	op->indLinN = indLinItems.size();
-	if (_globals.gindLin != NULL) Free(_globals.gindLin);
-	_globals.gindLin = Calloc(op->indLinN,int);
+	if (_globals.gindLin != NULL) R_Free(_globals.gindLin);
+	_globals.gindLin = R_Calloc(op->indLinN,int);
 	op->indLin = _globals.gindLin;
 	std::copy(indLinItems.begin(), indLinItems.end(), op->indLin);
 	if (me){


### PR DESCRIPTION
Dear Matt, dear RxODE team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses DOUBLE_EPS as well as Calloc/Free all of which go away (for DBL_EPSILON and R_Calloc/R_Free) when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This simple PR changes a handful of files so that the package installs when STRICT_R_HEADERS is set in the Rcpp header. Casual use of `grep -r` shows a few more `Calloc()` and `DBL_EPSILON` in your sources, you may want to consider defining STRICT_R_HEADERS in your central header files -- or maybe you don't want as you don't want to push change down to your users.  Either way, Rcpp will offer an opt-out you can set but we aim to enable this as a default.   

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.